### PR TITLE
Adding test about ActionController::Base.current_span

### DIFF
--- a/opentracing_rails.gemspec
+++ b/opentracing_rails.gemspec
@@ -18,5 +18,8 @@ Gem::Specification.new do |s|
     s.add_dependency('rack-tracer', '~> 0.3.0')
     s.add_dependency('faraday', '~> 0.14.0')
     s.add_dependency('faraday-tracer', '~> 0.2.0')
+
+    # Development dependencies
     s.add_development_dependency('rails', '> 3')
+    s.add_development_dependency('rspec', '~> 3.7')
 end

--- a/spec/lib/opentracing/action_controller/base_spec.rb
+++ b/spec/lib/opentracing/action_controller/base_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'action_controller'
+require 'opentracing_rails'
+
+describe 'ApplicationController' do
+  let(:controller) { ActionController::Base.new }
+
+  describe '#current_span' do
+    it { expect(controller).to respond_to :current_span }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+    config.order = :random
+end


### PR DESCRIPTION
This PR means to add a simple spec for `ActionController::Base.current_span`.
The test is so simple because IMO, if I unit-tested the access to request.env, I would test the implementation instead of the behavior. In case of changing the name of the req.env where the trace is stored, the test would pass anyway, but it will actually fail.